### PR TITLE
Make the per-material apparent brightness sliders behave similarly to the global ones

### DIFF
--- a/chunky/src/java/se/llbit/chunky/chunk/BlockPalette.java
+++ b/chunky/src/java/se/llbit/chunky/chunk/BlockPalette.java
@@ -341,15 +341,17 @@ public class BlockPalette {
       }
     });
     materialProperties.put("minecraft:redstone_wall_torch", block -> {
-      if (block instanceof  RedstoneWallTorch && ((RedstoneWallTorch) block).isLit()) {
+      if (block instanceof RedstoneWallTorch && ((RedstoneWallTorch) block).isLit()) {
         block.emittance = 1.0f;
       }
     });
     materialProperties.put("minecraft:torch", block -> {
       block.emittance = 50.0f;
+      block.apparentBrightnessModifier = 0.02f;
     });
     materialProperties.put("minecraft:wall_torch", block -> {
       block.emittance = 50.0f;
+      block.apparentBrightnessModifier = 0.02f;
     });
     materialProperties.put("minecraft:fire", block -> {
       block.emittance = 1.0f;
@@ -448,15 +450,19 @@ public class BlockPalette {
     });
     materialProperties.put("minecraft:soul_fire_torch", block -> { // MC 20w06a-20w16a
       block.emittance = 35.0f;
+      block.apparentBrightnessModifier = 0.02f;
     });
     materialProperties.put("minecraft:soul_torch", block -> { // MC >= 20w17a
       block.emittance = 35.0f;
+      block.apparentBrightnessModifier = 0.02f;
     });
     materialProperties.put("minecraft:soul_fire_wall_torch", block -> { // MC 20w06a-20w16a
       block.emittance = 35.0f;
+      block.apparentBrightnessModifier = 0.02f;
     });
     materialProperties.put("minecraft:soul_wall_torch", block -> { // MC >= 20w17a
       block.emittance = 35.0f;
+      block.apparentBrightnessModifier = 0.02f;
     });
     materialProperties.put("minecraft:soul_fire", block -> {
       block.emittance = 0.6f;

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -171,7 +171,7 @@ public class PathTracer implements RayTracer {
 
             if (scene.emittersEnabled && (!scene.isPreventNormalEmitterWithSampling() || scene.getEmitterSamplingStrategy() == EmitterSamplingStrategy.NONE || ray.depth == 0) && currentMat.emittance > Ray.EPSILON) {
 
-              apparentBrightness = addEmitted * currentMat.apparentBrightness * scene.apparentEmitterBrightness * scene.emitterIntensity;
+              apparentBrightness = addEmitted * currentMat.emittance * currentMat.apparentBrightnessModifier * scene.apparentEmitterBrightness * scene.emitterIntensity;
               ray.emittance.x = ray.color.x * ray.color.x *
                   currentMat.emittance * scene.emitterLightIntensity * scene.emitterIntensity;
               ray.emittance.y = ray.color.y * ray.color.y *

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -3400,7 +3400,7 @@ public class Scene implements JsonSerializable, Refreshable {
    */
   public void setApparentBrightness(String materialName, float value) {
     JsonObject material = materials.getOrDefault(materialName, new JsonObject()).object();
-    material.set("apparentBrightness", Json.of(value));
+    material.set("apparentBrightnessModifier", Json.of(value));
     materials.put(materialName, material);
     refresh(ResetReason.MATERIALS_CHANGED);
   }

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/MaterialsTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/MaterialsTab.java
@@ -50,7 +50,7 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
   private Scene scene;
 
   private final DoubleAdjuster emittance = new DoubleAdjuster();
-  private final DoubleAdjuster apparentBrightness = new DoubleAdjuster();
+  private final DoubleAdjuster apparentBrightnessModifier = new DoubleAdjuster();
   private final DoubleAdjuster specular = new DoubleAdjuster();
   private final DoubleAdjuster ior = new DoubleAdjuster();
   private final DoubleAdjuster perceptualSmoothness = new DoubleAdjuster();
@@ -62,10 +62,10 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
     emittance.setRange(0, 100);
     emittance.setTooltip("Intensity of the light emitted from the selected material.");
     emittance.clampMin();
-    apparentBrightness.setName("Apparent Brightness");
-    apparentBrightness.setRange(0, 100);
-    apparentBrightness.setTooltip("Apparent brightness of the texture of the selected material.");
-    apparentBrightness.clampMin();
+    apparentBrightnessModifier.setName("Brightness Modifier");
+    apparentBrightnessModifier.setRange(0, 100);
+    apparentBrightnessModifier.setTooltip("Controls the ratio between the selected material's apparent texture brightness and its actual light output.");
+    apparentBrightnessModifier.clampMin();
     specular.setName("Specular");
     specular.setRange(0, 1);
     specular.setTooltip("Reflectivity of the selected material.");
@@ -95,7 +95,7 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
     settings.setSpacing(10);
     settings.getChildren().addAll(
         new Label("Material Properties"),
-        emittance, apparentBrightness, specular, perceptualSmoothness, ior, metalness,
+        emittance, apparentBrightnessModifier, specular, perceptualSmoothness, ior, metalness,
         new Label("(set to zero to disable)"));
     setPadding(new Insets(10));
     setSpacing(15);
@@ -129,14 +129,14 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
       Collection<Block> blocks = MaterialStore.collections.get(materialName);
       for (Block block : blocks) {
         emAcc += block.emittance;
-        apparentBrightnessAcc += block.apparentBrightness;
+        apparentBrightnessAcc += block.apparentBrightnessModifier;
         specAcc += block.specular;
         iorAcc += block.ior;
         perceptualSmoothnessAcc += block.getPerceptualSmoothness();
         metalnessAcc += block.metalness;
       }
       emittance.set(emAcc / blocks.size());
-      apparentBrightness.set(apparentBrightnessAcc / blocks.size());
+      apparentBrightnessModifier.set(apparentBrightnessAcc / blocks.size());
       specular.set(specAcc / blocks.size());
       ior.set(iorAcc / blocks.size());
       perceptualSmoothness.set(perceptualSmoothnessAcc / blocks.size());
@@ -146,7 +146,7 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
       Material material = ExtraMaterials.idMap.get(materialName);
       if (material != null) {
         emittance.set(material.emittance);
-        apparentBrightness.set(material.apparentBrightness);
+        apparentBrightnessModifier.set(material.apparentBrightnessModifier);
         specular.set(material.specular);
         ior.set(material.ior);
         perceptualSmoothness.set(material.getPerceptualSmoothness());
@@ -157,7 +157,7 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
       Block block = new MinecraftBlock(materialName.substring(10), Texture.air);
       scene.getPalette().applyMaterial(block);
       emittance.set(block.emittance);
-      apparentBrightness.set(block.apparentBrightness);
+      apparentBrightnessModifier.set(block.apparentBrightnessModifier);
       specular.set(block.specular);
       ior.set(block.ior);
       perceptualSmoothness.set(block.getPerceptualSmoothness());
@@ -166,14 +166,14 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
     }
     if (materialExists) {
       emittance.onValueChange(value -> scene.setEmittance(materialName, value.floatValue()));
-      apparentBrightness.onValueChange(value -> scene.setApparentBrightness(materialName, value.floatValue()));
+      apparentBrightnessModifier.onValueChange(value -> scene.setApparentBrightness(materialName, value.floatValue()));
       specular.onValueChange(value -> scene.setSpecular(materialName, value.floatValue()));
       ior.onValueChange(value -> scene.setIor(materialName, value.floatValue()));
       perceptualSmoothness.onValueChange(value -> scene.setPerceptualSmoothness(materialName, value.floatValue()));
       metalness.onValueChange(value -> scene.setMetalness(materialName, value.floatValue()));
     } else {
       emittance.onValueChange(value -> {});
-      apparentBrightness.onValueChange(value -> {});
+      apparentBrightnessModifier.onValueChange(value -> {});
       specular.onValueChange(value -> {});
       ior.onValueChange(value -> {});
       perceptualSmoothness.onValueChange(value -> {});

--- a/chunky/src/java/se/llbit/chunky/world/Material.java
+++ b/chunky/src/java/se/llbit/chunky/world/Material.java
@@ -61,9 +61,9 @@ public abstract class Material {
   public float emittance = 0;
 
   /**
-   * The apparent brightness of the material.
+   * Multiplier for the apparent brightness of the material when acting as an emitter.
    */
-  public float apparentBrightness = 1;
+  public float apparentBrightnessModifier = 1;
 
   /**
    * The (linear) roughness controlling how rough a shiny block appears. A value of 0 makes the
@@ -108,7 +108,7 @@ public abstract class Material {
     solid = true;
     specular = 0;
     emittance = 0;
-    apparentBrightness = 1;
+    apparentBrightnessModifier = 1;
     roughness = 0;
     subSurfaceScattering = false;
   }
@@ -129,7 +129,7 @@ public abstract class Material {
     ior = json.get("ior").floatValue(ior);
     specular = json.get("specular").floatValue(specular);
     emittance = json.get("emittance").floatValue(emittance);
-    apparentBrightness = json.get("apparentBrightness").floatValue(apparentBrightness);
+    apparentBrightnessModifier = json.get("apparentBrightnessModifier").floatValue(apparentBrightnessModifier);
     roughness = json.get("roughness").floatValue(roughness);
     metalness = json.get("metalness").floatValue(metalness);
   }


### PR DESCRIPTION
Before, the per-material settings were being treated differently (and imo, less intuitively) than the global settings for emitter brightness.

Using this scene for comparison:
![image](https://github.com/Peregrine05/chunky/assets/46458276/9c8819f6-2bdc-4872-be29-45ee2fd0e2e7)

Changing the global emitter brightness from 1 to 4 results in this; as expected, it affects both apparent brightness and actual emissivity:
![image](https://github.com/Peregrine05/chunky/assets/46458276/7b9995fc-a2ff-4da9-b3db-b62414073945)

Before my changes, this is what happens if you set only jack-o-lanterns to an emittance of 4; the apparent brightness doesn't change unless it is also altered manually:
![image](https://github.com/Peregrine05/chunky/assets/46458276/ac5ae841-5656-472d-9031-33e23462c48c)

With my changes, this is fixed by also multiplying by the material's emittance when determining its apparent brightness:
![image](https://github.com/Peregrine05/chunky/assets/46458276/50a6793a-ba01-434b-8acb-6b8d8db55ebb)

This PR also sets defaults for torches and soul torches to maintain close to the previous behavior, although these should probably be reconsidered in the future.